### PR TITLE
Fix WebSocket 1008 policy violation error in OpenClaw adapter

### DIFF
--- a/src/superclaw/adapters/openclaw.py
+++ b/src/superclaw/adapters/openclaw.py
@@ -54,7 +54,7 @@ class OpenClawAdapter(AgentAdapter):
 
             self._ws = await websockets.connect(
                 self.target,
-                additional_headers=headers if headers else None,
+                additional_headers=headers if headers else {},
                 open_timeout=self.open_timeout,
             )
 


### PR DESCRIPTION
## Problem
Fixes #1: SuperClaw returns 1008 (policy violation) invalid request frame when attacking OpenClaw

## Root Cause
The OpenClaw adapter was passing `additional_headers=None` to `websockets.connect()` when no authorization token was provided. Many WebSocket servers enforce header validation rules and reject requests with `None` headers, resulting in a 1008 policy violation error.

## Solution
Changed the conditional to pass an empty dictionary `{}` instead of `None` when no custom headers exist. This is the standard way to indicate "no custom headers" to the websockets library.

## Changes
- Modified `src/superclaw/adapters/openclaw.py` line 57: `additional_headers=headers if headers else {}` instead of `None`